### PR TITLE
input: odroidgo3-joypad: add optional amux-channel-mapping DT property

### DIFF
--- a/drivers/input/joystick/odroidgo3-joypad.c
+++ b/drivers/input/joystick/odroidgo3-joypad.c
@@ -1002,6 +1002,20 @@ static int joypad_adc_setup(struct device *dev, struct joypad *joypad)
 					__func__, nbtn);
 				return -EINVAL;
 		}
+		/*
+		 * Minimal change:
+		 * Try to read the physical MUX channel for this logical axis
+		 * from DTS property "amux-channel-mapping".
+		 * If the property is missing or shorter than amux_count,
+		 * fall back to the original default mapping (adc->amux_ch = nbtn).
+		 *
+		 * Example DTS:
+		 *   amux-channel-mapping = <2 3 1 0>;
+		 */
+		if (of_property_read_u32_index(dev->of_node,
+					       "amux-channel-mapping",
+					       nbtn, &adc->amux_ch))
+			adc->amux_ch = nbtn;
 	}
 	return	0;
 }


### PR DESCRIPTION
This PR adds support for an optional device tree property
`amux-channel-mapping` in the odroidgo3-joypad driver.

Currently the driver assumes the AMUX channel order matches the
logical axis order (0=ABS_RY, 1=ABS_RX, 2=ABS_Y, 3=ABS_X).  
On some boards the wiring differs, requiring flexibility.

With this change, the DTS can specify a mapping like:

    amux-channel-mapping = <2 3 1 0>;

If the property is missing or incomplete, the driver falls back to
the original fixed mapping, so existing DTS files remain unaffected.

### Why
- Improves DTS flexibility  
- Keeps backward compatibility  
- Minimal code change, no functional impact on existing devices

Signed-off-by: lcdyk0517 <lcdyk0517@qq.com>
